### PR TITLE
Master scp fix

### DIFF
--- a/src/dData.pas
+++ b/src/dData.pas
@@ -2397,11 +2397,13 @@ procedure TdmData.LoadMasterSCP;
 var
   i   : LongInt=1;
   f   : TextFile;
+  l   : LongInt;
   tmp : String;
 begin
   if FileExists(fHomeDir+'MASTER.SCP') then
   begin
-    SetLength(aSCP,80000);
+    l := Length(aSCP);
+    if fDebugLevel>=3 then WriteLn('loading master.scp into aSCP[',l,']');
     AssignFile(f,fHomeDir+'MASTER.SCP');
     Reset(f);
     while not eof(f) do
@@ -2412,13 +2414,19 @@ begin
         Continue;
       if tmp[1]='#' then //skip comments
         Continue;
+
+      if i>l then  // avoid buffer overflow - check before you write!
+      begin
+        l := l + 1000; // increment array size by 1k
+        SetLength(aSCP, l);
+        if fDebugLevel>=3 then WriteLn('incremented array to size ',l);
+      end;
+
       aSCP[i-1] := tmp;
       inc(i);
-      if i>Length(aSCP) then
-        SetLength(aSCP, Length(aSCP) + 100000)
     end;
     CloseFile(f);
-    SetLength(aSCP,i);
+    SetLength(aSCP,i);  // truncate the array to the actual length we read
     if fDebugLevel>=1 then Writeln('Loaded ',i,' SCP calls')
   end
 end;

--- a/src/dData.pas
+++ b/src/dData.pas
@@ -2414,7 +2414,7 @@ begin
         Continue;
       aSCP[i-1] := tmp;
       inc(i);
-      if i>80000 then
+      if i>Length(aSCP) then
         SetLength(aSCP, Length(aSCP) + 100000)
     end;
     CloseFile(f);

--- a/src/dData.pas
+++ b/src/dData.pas
@@ -2415,7 +2415,7 @@ begin
       aSCP[i-1] := tmp;
       inc(i);
       if i>80000 then
-        SetLength(aSCP,100000)
+        SetLength(aSCP, Length(aSCP) + 100000)
     end;
     CloseFile(f);
     SetLength(aSCP,i);


### PR DESCRIPTION
This change fixes a fatal crash I experienced after downloading the latest DXCC data. In the latest DXCC data bundle, the MASTER.SCP file is over 700k lines long(!!)  The code, as it was, only allowed for the file to grow to 100k lines. With this change,
it can grow dynamically without causing a problem.