### PR TITLE
Cosmetic: fix for dark themes

### DIFF
--- a/src/fMain.lfm
+++ b/src/fMain.lfm
@@ -344,7 +344,6 @@ object frmMain: TfrmMain
       Anchors = [akLeft, akBottom]
       BorderSpacing.Left = 10
       Caption = '10000'
-      Font.Color = clBlack
       Font.Style = [fsBold]
       Layout = tlBottom
       ParentColor = False
@@ -410,7 +409,6 @@ object frmMain: TfrmMain
       AutoSize = False
       BorderSpacing.Right = 10
       Caption = '150'
-      Font.Color = clBlack
       Font.Style = [fsBold]
       Layout = tlBottom
       ParentColor = False


### PR DESCRIPTION
Modified lblQSOCount and lblDXCCCmf to use the default text color
instead of 'black' so they will look good in dark themes.

I tested it on my machine and it still looks the same with a normal theme.